### PR TITLE
Installation documentation fixes

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ Run the following command to install the required system packages:
 
 ```
 $ sudo apt-get update
-$ sudo apt-get install python-dev python-pip imagemagick
+$ sudo apt-get install -y python-dev python-pip imagemagick libffi-dev libssl-dev git
 ```
 
 ## Pimotion application installation
@@ -77,9 +77,10 @@ $ git clone https://github.com/citrusbyte/pimotion.git
 
 ### Dependency installation
 
-In the pimotion folder run the following command to install all the dependent python packages:
+In the pimotion folder run the following commands to install all the dependent python packages:
 
 ```
+$ sudo pip install http://effbot.org/downloads/Imaging-1.1.7.tar.gz
 $ sudo pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
The following packages added to to system dependencies installation command:
- Adds `libffi-dev` per https://github.com/citrusbyte/pimotion#1-system-dependencies
- Adds `libssl-dev`, as is required by [cryptography](https://cryptography.io/en/latest/installation/) which is a dependency for [pyOpenSSL](https://pypi.python.org/pypi/pyOpenSSL)
- Adds `git` which is required in order to `git clone` the Pimotion repository

Adds `PIL==1.1.7` installation via remote source in an attempt to solve https://github.com/citrusbyte/pimotion/issues/5

---

With these changes, by following these instructions I was able to successfully install Pimotion onto a Raspberry Pi 2 running Raspbian Jessie Lite version May 2016. Prior to these updates, I was unable to successfully install Pimotion in the same env
